### PR TITLE
always enable displayName

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = api => {
       'babel-plugin-styled-components',
       {
         ssr: false,
-        displayName: !production
+        displayName: true
       }
     ]
   ]


### PR DESCRIPTION
v5.0.0-beta.0 conflicts the class name with page content class name.

Temporarily enable displayName to avoid collisions.